### PR TITLE
Support client certificates if the server requires them (mTLS)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -154,6 +154,7 @@ kotlin {
                 implementation(libs.androidx.media3.ui)
 
                 implementation(libs.material)
+                implementation(libs.coil.network.okhttp)
             }
         }
 

--- a/composeApp/src/androidMain/kotlin/de/kitshn/AndroidApp.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/AndroidApp.kt
@@ -8,7 +8,12 @@ class AndroidApp : Application() {
 
     override fun attachBaseContext(base: Context?) {
         super.attachBaseContext(base)
+        INSTANCE = this
         initKitshnAcra()
+    }
+
+    companion object {
+        lateinit var INSTANCE: AndroidApp
     }
 
 }

--- a/composeApp/src/androidMain/kotlin/de/kitshn/api/tandoor/TandoorHttpClient.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/api/tandoor/TandoorHttpClient.android.kt
@@ -1,0 +1,72 @@
+package de.kitshn.api.tandoor
+
+import android.security.KeyChain
+import de.kitshn.AndroidApp
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import javax.net.ssl.KeyManager
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509KeyManager
+import java.net.Socket
+import java.security.Principal
+
+actual fun createTandoorHttpClient(
+    credentials: TandoorCredentials,
+    onCertificateRequested: () -> Unit
+): HttpClient {
+    return HttpClient(OkHttp) {
+        followRedirects = true
+
+        engine {
+            config {
+                sslSocketFactory(
+                    SSLContext.getInstance("TLS").apply {
+                        init(
+                            arrayOf(
+                                object : X509KeyManager {
+                                    override fun getClientAliases(keyType: String?, issuers: Array<out Principal>?): Array<String>? = null
+                                    
+                                    override fun chooseClientAlias(keyType: Array<out String>?, issuers: Array<out Principal>?, socket: Socket?): String? {
+                                        onCertificateRequested()
+                                        return credentials.clientCertificateAlias
+                                    }
+
+                                    override fun getServerAliases(keyType: String?, issuers: Array<out Principal>?): Array<String>? = null
+                                    
+                                    override fun chooseServerAlias(keyType: String?, issuers: Array<out Principal>?, socket: Socket?): String? = null
+                                    
+                                    override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
+                                        return if (alias == credentials.clientCertificateAlias && alias != null) {
+                                            KeyChain.getCertificateChain(AndroidApp.INSTANCE, alias)
+                                        } else null
+                                    }
+
+                                    override fun getPrivateKey(alias: String?): PrivateKey? {
+                                        return if (alias == credentials.clientCertificateAlias && alias != null) {
+                                            KeyChain.getPrivateKey(AndroidApp.INSTANCE, alias)
+                                        } else null
+                                    }
+                                }
+                            ),
+                            null,
+                            null
+                        )
+                    }.socketFactory,
+                    // We need a trust manager, but using the default system one is tricky to extract easily without custom setup.
+                    // However, OkHttp uses the system default if we don't provide one, but we are setting the SSLSocketFactory.
+                    // Let's try to get the default TrustManager.
+                    getDefaultX509TrustManager()
+                )
+            }
+        }
+    }
+}
+
+private fun getDefaultX509TrustManager(): javax.net.ssl.X509TrustManager {
+    val factory = javax.net.ssl.TrustManagerFactory.getInstance(javax.net.ssl.TrustManagerFactory.getDefaultAlgorithm())
+    factory.init(null as KeyStore?)
+    return factory.trustManagers.first { it is javax.net.ssl.X509TrustManager } as javax.net.ssl.X509TrustManager
+}

--- a/composeApp/src/androidMain/kotlin/de/kitshn/utils/ClientCertificateUtils.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/utils/ClientCertificateUtils.android.kt
@@ -1,0 +1,34 @@
+package de.kitshn.utils
+
+import android.app.Activity
+import android.security.KeyChain
+import android.security.KeyChainAliasCallback
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import de.kitshn.AppActivity
+
+actual class ClientCertificateSelector(private val activity: Activity) {
+    actual fun selectClientCertificate(callback: (alias: String?) -> Unit) {
+        KeyChain.choosePrivateKeyAlias(
+            activity,
+            object : KeyChainAliasCallback {
+                override fun alias(alias: String?) {
+                    callback(alias)
+                }
+            },
+            null, null, null, -1, null
+        )
+    }
+}
+
+@Composable
+actual fun rememberClientCertificateSelector(): ClientCertificateSelector {
+    val context = LocalContext.current
+    return remember(context) {
+        // Assuming the context is an Activity or can be cast to one, which is true for Compose on Android usually.
+        // It might be a wrapper (ContextWrapper), so we might need to unwrap, but casting usually works for direct Activity.
+        // Keep it simple for now.
+        ClientCertificateSelector(context as Activity)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.android.kt
@@ -1,0 +1,73 @@
+package de.kitshn.utils
+
+import android.security.KeyChain
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import de.kitshn.AndroidApp
+import de.kitshn.api.tandoor.TandoorCredentials
+import okhttp3.OkHttpClient
+import java.security.KeyStore
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.net.Socket
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509KeyManager
+import javax.net.ssl.X509TrustManager
+
+actual fun createImageLoader(
+    context: PlatformContext,
+    credentials: TandoorCredentials
+): ImageLoader {
+    val okHttpClient = if (credentials.clientCertificateAlias != null) {
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(
+                arrayOf(
+                    object : X509KeyManager {
+                        override fun getClientAliases(keyType: String?, issuers: Array<out Principal>?): Array<String>? = null
+
+                        override fun chooseClientAlias(keyType: Array<out String>?, issuers: Array<out Principal>?, socket: Socket?): String? {
+                            return credentials.clientCertificateAlias
+                        }
+
+                        override fun getServerAliases(keyType: String?, issuers: Array<out Principal>?): Array<String>? = null
+
+                        override fun chooseServerAlias(keyType: String?, issuers: Array<out Principal>?, socket: Socket?): String? = null
+
+                        override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
+                            return if (alias == credentials.clientCertificateAlias && alias != null) {
+                                KeyChain.getCertificateChain(AndroidApp.INSTANCE, alias)
+                            } else null
+                        }
+
+                        override fun getPrivateKey(alias: String?): PrivateKey? {
+                            return if (alias == credentials.clientCertificateAlias && alias != null) {
+                                KeyChain.getPrivateKey(AndroidApp.INSTANCE, alias)
+                            } else null
+                        }
+                    }
+                ),
+                null,
+                null
+            )
+        }
+
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        trustManagerFactory.init(null as KeyStore?)
+        val trustManager = trustManagerFactory.trustManagers.first { it is X509TrustManager } as X509TrustManager
+
+        OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .build()
+    } else {
+        OkHttpClient.Builder().build()
+    }
+
+    return ImageLoader.Builder(context)
+        .components {
+            add(OkHttpNetworkFetcherFactory(okHttpClient))
+        }
+        .build()
+}

--- a/composeApp/src/commonMain/kotlin/de/kitshn/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/App.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -25,12 +26,14 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import coil3.compose.LocalPlatformContext
+import coil3.compose.setSingletonImageLoaderFactory
 import de.kitshn.api.tandoor.TandoorClient
 import de.kitshn.api.tandoor.TandoorCredentials
 import de.kitshn.cache.ShoppingListEntriesCache
 import de.kitshn.ui.route.navigation.PrimaryNavigation
 import de.kitshn.ui.theme.KitshnTheme
 import de.kitshn.ui.theme.custom.AvailableColorSchemes
+import de.kitshn.utils.createImageLoader
 import kotlinx.coroutines.delay
 
 private val SavedTandoorClient = mutableStateOf<TandoorClient?>(null)
@@ -61,6 +64,15 @@ internal fun App(
     }
 
     val density = LocalDensity.current
+
+    val credentials = vm.tandoorClient?.credentials
+    setSingletonImageLoaderFactory { context ->
+        if (credentials != null) {
+            createImageLoader(context, credentials)
+        } else {
+            coil3.ImageLoader.Builder(context).build()
+        }
+    }
 
     DisposableEffect(key1 = Unit) {
         onDispose {

--- a/composeApp/src/commonMain/kotlin/de/kitshn/KitshnViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/KitshnViewModel.kt
@@ -176,12 +176,7 @@ class KitshnViewModel(
             try {
                 val response = tandoorClient!!.reqAny(
                     endpoint = "/",
-                    _method = HttpMethod.Get,
-                    customHttpClient = HttpClient {
-                        install(HttpTimeout) {
-                            requestTimeoutMillis = 2000
-                        }
-                    }
+                    _method = HttpMethod.Get
                 )
 
                 if(response.status == HttpStatusCode.OK)
@@ -196,28 +191,23 @@ class KitshnViewModel(
                 try {
                     val response = tandoorClient!!.reqAny(
                         endpoint = "/",
-                        _method = HttpMethod.Get,
-                        customHttpClient = HttpClient {
-                            install(HttpTimeout) {
-                                requestTimeoutMillis = 5000
-                            }
-                        }
+                        _method = HttpMethod.Get
                     )
 
                     if(response.status == HttpStatusCode.OK)
                         isOffline = false
                 } catch(_: TandoorRequestsError) {
                 } catch(_: SerializationException) {
-                }
+            }
 
-                if(isOffline) {
-                    uiState.offlineState.isOffline = true
+            if(isOffline) {
+                uiState.offlineState.isOffline = true
 
-                    // automatically switch to shopping page if offline
-                    if((Clock.System.now().toEpochMilliseconds() - initTime) < 8000) {
-                        if(navHostController?.currentDestination?.route != "main") return@launch
-                        if(mainSubNavHostController?.currentDestination?.route != "home") return@launch
-                        mainSubNavHostController?.navigate("shopping")
+                // automatically switch to shopping page if offline
+                if((Clock.System.now().toEpochMilliseconds() - initTime) < 8000) {
+                    if(navHostController?.currentDestination?.route != "main") return@launch
+                    if(mainSubNavHostController?.currentDestination?.route != "home") return@launch
+                    mainSubNavHostController?.navigate("shopping")
                     }
                 } else {
                     uiState.offlineState.isOffline = false

--- a/composeApp/src/commonMain/kotlin/de/kitshn/api/tandoor/TandoorClient.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/api/tandoor/TandoorClient.kt
@@ -48,20 +48,28 @@ data class TandoorCredentials(
     val password: String = "",
     var token: TandoorCredentialsToken? = null,
     val cookie: String? = null,
-    val customHeaders: List<TandoorCredentialsCustomHeader> = listOf()
+    val customHeaders: List<TandoorCredentialsCustomHeader> = listOf(),
+    var clientCertificateAlias: String? = null
 )
+
+expect fun createTandoorHttpClient(
+    credentials: TandoorCredentials,
+    onCertificateRequested: () -> Unit
+): HttpClient
 
 class TandoorClient(
     val credentials: TandoorCredentials
 ) {
 
-    val httpClient = HttpClient {
-        followRedirects = true
+    var certificateRequested: Boolean = false
+
+    val httpClient = createTandoorHttpClient(credentials) {
+        certificateRequested = true
     }
 
-    val longHttpClient = HttpClient {
-        followRedirects = true
-
+    val longHttpClient = createTandoorHttpClient(credentials) {
+        certificateRequested = true
+    }.config { 
         install(HttpTimeout) {
             connectTimeoutMillis = 60000
             requestTimeoutMillis = 60000

--- a/composeApp/src/commonMain/kotlin/de/kitshn/model/form/item/KitshnFormImageUploadItem.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/model/form/item/KitshnFormImageUploadItem.kt
@@ -58,9 +58,6 @@ class KitshnFormImageUploadItem(
     override fun Render(
         modifier: Modifier
     ) {
-        val context = LocalPlatformContext.current
-        val imageLoader = remember { ImageLoader(context) }
-
         var imageLoadingState by remember {
             mutableStateOf<AsyncImagePainter.State>(
                 AsyncImagePainter.State.Loading(null)
@@ -92,7 +89,6 @@ class KitshnFormImageUploadItem(
                             },
                             contentDescription = label(),
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .loadingPlaceHolder(imageLoadingState.translateState())
@@ -105,7 +101,6 @@ class KitshnFormImageUploadItem(
                             },
                             contentDescription = label(),
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .loadingPlaceHolder(imageLoadingState.translateState())

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/recipe/RecipeSearchField.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/input/recipe/RecipeSearchField.kt
@@ -31,9 +31,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.TandoorClient
 import de.kitshn.api.tandoor.TandoorRequestState
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipeOverview
@@ -59,8 +57,6 @@ fun BaseRecipeSearchField(
         onValueChange: (value: String) -> Unit
     ) -> Unit
 ) {
-    val context = LocalPlatformContext.current
-
     var selectedRecipe by remember { mutableStateOf<TandoorRecipeOverview?>(null) }
     LaunchedEffect(selectedRecipe) { onValueChange(selectedRecipe?.id) }
 
@@ -106,7 +102,6 @@ fun BaseRecipeSearchField(
                         model = selectedRecipe?.loadThumbnail(),
                         contentDescription = stringResource(Res.string.common_title_image),
                         contentScale = ContentScale.Crop,
-                        imageLoader = ImageLoader(context),
                         modifier = Modifier
                             .size(36.dp)
                             .clip(RoundedCornerShape(8.dp))

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCard.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCard.kt
@@ -37,9 +37,6 @@ fun HorizontalRecipeCard(
     onClick: (recipeOverview: TandoorRecipeOverview) -> Unit,
     onLongClick: (recipeOverview: TandoorRecipeOverview) -> Unit
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     Card(
         modifier = modifier,
         onClick = { onClick(recipeOverview) }
@@ -60,7 +57,6 @@ fun HorizontalRecipeCard(
                         model = recipeOverview.loadThumbnail(),
                         contentDescription = recipeOverview.name,
                         contentScale = ContentScale.Crop,
-                        imageLoader = imageLoader,
                         modifier = Modifier
                             .size(64.dp)
                             .clip(RoundedCornerShape(16.dp))

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCardLink.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/HorizontalRecipeCardLink.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -18,9 +17,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipeOverview
 import de.kitshn.ui.selectionMode.SelectionModeState
 import de.kitshn.ui.selectionMode.values.selectionModeListItemColors
@@ -35,9 +32,6 @@ fun HorizontalRecipeCardLink(
     defaultColors: ListItemColors = ListItemDefaults.colors(),
     onClick: (recipeOverview: TandoorRecipeOverview) -> Unit
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val hapticFeedback = LocalHapticFeedback.current
 
     val colors = ListItemDefaults.selectionModeListItemColors(
@@ -75,7 +69,6 @@ fun HorizontalRecipeCardLink(
                             model = recipeOverview.loadThumbnail(),
                             contentDescription = recipeOverview.name,
                             contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader,
                             modifier = Modifier
                                 .size(48.dp)
                                 .clip(RoundedCornerShape(8.dp))

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/RecipeCard.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/RecipeCard.kt
@@ -66,9 +66,6 @@ fun RecipeCard(
     onClickKeyword: (keyword: TandoorKeywordOverview) -> Unit,
     onClick: (recipeOverview: TandoorRecipeOverview) -> Unit,
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val hapticFeedback = LocalHapticFeedback.current
     val hazeState = remember { HazeState() }
 
@@ -124,7 +121,6 @@ fun RecipeCard(
                     },
                     contentDescription = recipeOverview?.name,
                     contentScale = ContentScale.Crop,
-                    imageLoader = imageLoader,
                     modifier = Modifier
                         .fillMaxWidth()
                         .run {

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/step/RecipeStepMultimediaBox.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipe/step/RecipeStepMultimediaBox.kt
@@ -31,10 +31,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.model.TandoorStep
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipe
 import de.kitshn.ui.dialog.AdaptiveFullscreenDialog
@@ -54,9 +52,6 @@ fun RecipeStepMultimediaBox(
     additionalContent: @Composable () -> Unit = { },
     placeholder: @Composable () -> Unit = { }
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val isVideo = (step.file?.name ?: "").contains("video")
 
     if(isVideo && !isVideoSupported()) {
@@ -98,7 +93,6 @@ fun RecipeStepMultimediaBox(
             },
             contentDescription = step.name,
             contentScale = ContentScale.Crop,
-            imageLoader = imageLoader,
             modifier = Modifier
                 .padding(contentPadding)
                 .fillMaxWidth()
@@ -159,9 +153,6 @@ private fun ImageDialog(
     onDismiss: () -> Unit,
     step: TandoorStep
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     var imageLoadingState by remember {
         mutableStateOf<AsyncImagePainter.State>(
             AsyncImagePainter.State.Loading(
@@ -196,7 +187,6 @@ private fun ImageDialog(
             },
             contentDescription = step.name,
             contentScale = ContentScale.Fit,
-            imageLoader = imageLoader,
             modifier = Modifier
                 .loadingPlaceHolder(
                     loadingState = imageLoadingState.translateState(),

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipebook/HorizontalRecipeBookCard.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/component/model/recipebook/HorizontalRecipeBookCard.kt
@@ -69,9 +69,6 @@ fun HorizontalRecipeBookCard(
 
     onClick: (recipeBook: TandoorRecipeBook) -> Unit = {}
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val hapticFeedback = LocalHapticFeedback.current
 
     val colors = CardDefaults.selectionModeCardColors(
@@ -168,7 +165,6 @@ fun HorizontalRecipeBookCard(
                                 model = recipeBook?.loadThumbnail(),
                                 contentDescription = recipeBook?.name,
                                 contentScale = ContentScale.Crop,
-                                imageLoader = imageLoader,
                                 modifier = Modifier
                                     .height(42.dp)
                                     .width(42.dp)

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/dialog/recipe/import/RecipeImportCommon.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/dialog/recipe/import/RecipeImportCommon.kt
@@ -37,9 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.LocalPlatformContext
 import de.kitshn.api.tandoor.TandoorRequestState
 import de.kitshn.api.tandoor.TandoorRequestStateState
 import de.kitshn.api.tandoor.model.recipe.TandoorRecipe
@@ -143,9 +141,6 @@ fun LazyListScope.RecipeImportCommon(
         }
 
         item {
-            val context = LocalPlatformContext.current
-            val imageLoader = remember { ImageLoader(context) }
-
             var showChoosePhotoDialog by remember { mutableStateOf(false) }
 
             HorizontalMultiBrowseCarousel(
@@ -172,8 +167,7 @@ fun LazyListScope.RecipeImportCommon(
                                     },
                                 model = data.uploadImage,
                                 contentDescription = "",
-                                contentScale = ContentScale.Crop,
-                                imageLoader = imageLoader
+                                contentScale = ContentScale.Crop
                             )
 
                             Box(
@@ -229,8 +223,7 @@ fun LazyListScope.RecipeImportCommon(
                                 },
                             model = url,
                             contentDescription = url,
-                            contentScale = ContentScale.Crop,
-                            imageLoader = imageLoader
+                            contentScale = ContentScale.Crop
                         )
 
                         if(data.selectedImageUrl == url) Box(

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/recipe/cook/page/RecipeDone.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/route/recipe/cook/page/RecipeDone.kt
@@ -78,9 +78,6 @@ fun RouteRecipeCookPageDone(
     recipe: TandoorRecipe,
     servings: Int
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val coroutineScope = rememberCoroutineScope()
     val requestCookLogCreateState = rememberTandoorRequestState()
 
@@ -135,7 +132,6 @@ fun RouteRecipeCookPageDone(
                         model = recipe.loadThumbnail(),
                         contentDescription = recipe.name,
                         contentScale = ContentScale.Crop,
-                        imageLoader = imageLoader,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(180.dp)

--- a/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/ui/view/recipe/details/RecipeDetails.kt
@@ -215,9 +215,6 @@ fun ViewRecipeDetails(
 
     overrideServings: Double? = null
 ) {
-    val context = LocalPlatformContext.current
-    val imageLoader = remember { ImageLoader(context) }
-
     val websiteHandler = launchWebsiteHandler()
     val shareContentHandler = shareContentHandler()
 
@@ -654,7 +651,6 @@ fun ViewRecipeDetails(
                     model = recipeOverview.loadThumbnail(),
                     contentDescription = recipeOverview.name,
                     contentScale = ContentScale.Crop,
-                    imageLoader = imageLoader,
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(16f / 9f)

--- a/composeApp/src/commonMain/kotlin/de/kitshn/utils/ClientCertificateUtils.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/utils/ClientCertificateUtils.kt
@@ -1,0 +1,10 @@
+package de.kitshn.utils
+
+import androidx.compose.runtime.Composable
+
+expect class ClientCertificateSelector {
+    fun selectClientCertificate(callback: (alias: String?) -> Unit)
+}
+
+@Composable
+expect fun rememberClientCertificateSelector(): ClientCertificateSelector

--- a/composeApp/src/commonMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.kt
+++ b/composeApp/src/commonMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.kt
@@ -1,0 +1,10 @@
+package de.kitshn.utils
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import de.kitshn.api.tandoor.TandoorCredentials
+
+expect fun createImageLoader(
+    context: PlatformContext,
+    credentials: TandoorCredentials
+): ImageLoader

--- a/composeApp/src/iosMain/kotlin/de/kitshn/api/tandoor/TandoorHttpClient.ios.kt
+++ b/composeApp/src/iosMain/kotlin/de/kitshn/api/tandoor/TandoorHttpClient.ios.kt
@@ -1,0 +1,15 @@
+package de.kitshn.api.tandoor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+
+actual fun createTandoorHttpClient(
+    credentials: TandoorCredentials,
+    onCertificateRequested: () -> Unit
+): HttpClient {
+    return HttpClient(Darwin) {
+        followRedirects = true
+        
+        // TODO: Implement client certificate support for iOS
+    }
+}

--- a/composeApp/src/iosMain/kotlin/de/kitshn/utils/ClientCertificateUtils.ios.kt
+++ b/composeApp/src/iosMain/kotlin/de/kitshn/utils/ClientCertificateUtils.ios.kt
@@ -1,0 +1,16 @@
+package de.kitshn.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+actual class ClientCertificateSelector {
+    actual fun selectClientCertificate(callback: (alias: String?) -> Unit) {
+        // TODO: Implement client certificate selection for iOS
+        callback(null)
+    }
+}
+
+@Composable
+actual fun rememberClientCertificateSelector(): ClientCertificateSelector {
+    return remember { ClientCertificateSelector() }
+}

--- a/composeApp/src/iosMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.ios.kt
+++ b/composeApp/src/iosMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.ios.kt
@@ -1,0 +1,13 @@
+package de.kitshn.utils
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import de.kitshn.api.tandoor.TandoorCredentials
+
+actual fun createImageLoader(
+    context: PlatformContext,
+    credentials: TandoorCredentials
+): ImageLoader {
+    // iOS: Default ImageLoader (no client certificate support yet)
+    return ImageLoader.Builder(context).build()
+}

--- a/composeApp/src/jvmMain/kotlin/de/kitshn/api/tandoor/TandoorHttpClient.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/kitshn/api/tandoor/TandoorHttpClient.jvm.kt
@@ -1,0 +1,13 @@
+package de.kitshn.api.tandoor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+
+actual fun createTandoorHttpClient(
+    credentials: TandoorCredentials,
+    onCertificateRequested: () -> Unit
+): HttpClient {
+    return HttpClient(OkHttp) {
+        followRedirects = true
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/de/kitshn/utils/ClientCertificateUtils.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/kitshn/utils/ClientCertificateUtils.jvm.kt
@@ -1,0 +1,15 @@
+package de.kitshn.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+actual class ClientCertificateSelector {
+    actual fun selectClientCertificate(callback: (alias: String?) -> Unit) {
+        callback(null)
+    }
+}
+
+@Composable
+actual fun rememberClientCertificateSelector(): ClientCertificateSelector {
+    return remember { ClientCertificateSelector() }
+}

--- a/composeApp/src/jvmMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/kitshn/utils/CoilImageLoaderFactory.jvm.kt
@@ -1,0 +1,13 @@
+package de.kitshn.utils
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import de.kitshn.api.tandoor.TandoorCredentials
+
+actual fun createImageLoader(
+    context: PlatformContext,
+    credentials: TandoorCredentials
+): ImageLoader {
+    // JVM/Desktop: Default ImageLoader (no client certificate support yet)
+    return ImageLoader.Builder(context).build()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 coil = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 compose-video = { module = "io.sanghun:compose-video", version.ref = "composeVideo" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }


### PR DESCRIPTION
I have my tandoor server protected via mTLS to prevent unauthorized devices from even getting access to the server.  I also just found this app, and wanted to check it out.  Unfortunately, it didn't work with my server and I was getting a "client certificate not sent" error.

I know that Android has it's own implementation of a certificate store as that is what other apps like Home Assistant use.  So I tried to see if I could get at least the Android implementation of this app to work with that certificate store.  I did the following:

1.  If when testing a server it states that it requires a client certificate, let the user select a certificate from the android store.  For iOS and JVM, this is currently left unimplemented as I don't know what iOS has available and I'm not sure what is standard for JVM apps.  Save the pointer to the certificate alongside the credentials.
2. Refactor instantiation of the HttpClient to be platform specific and for the android version use the certificate from the OS store.
3. Stop using a custom client in the ViewModel.  I'm not quite sure why there was a custom client there other than to override the timeout.  I don't think it makes sense creating different clients all over the place with different timeout values.

After this, I got everything working, but images weren't loading.  I hadn't seen that images were loaded via ImageLoader.  To fix that, I had to:

1.  Refactor the ImageLoader to be created in one spot rather than throughout all the individual UI components.
2. Implement a singleton factory to create the ImageLoader and have it also use similar logic to fetch the certificate on Android.

I've got a debug build of this running on my phone and it's able to connect and I'm able to browse my tandoor instance.