### PR TITLE
fix: mealplan step amount buttons ceil & floor

### DIFF
--- a/shared/src/commonMain/kotlin/de/kitshn/Utils.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/Utils.kt
@@ -53,6 +53,7 @@ import kotlinx.serialization.json.internal.FormatLanguage
 import nl.jacobras.humanreadable.HumanReadable
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.floor
+import kotlin.math.round
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -161,6 +162,11 @@ fun formatDecimalToFraction(decimal: Double): String {
     else if(decimal <= 0.78) "¾"
     else if(decimal <= 0.84) "⅘"
     else "⅞"
+}
+
+fun Double.roundToPrecision(precision: Double): Double {
+    if(precision <= 0.0) return this
+    return round(this / precision) * precision
 }
 
 fun Double.formatAmount(fractional: Boolean = true): String {

--- a/shared/src/commonMain/kotlin/de/kitshn/model/form/item/field/KitshnFormDoubleFieldItem.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/model/form/item/field/KitshnFormDoubleFieldItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import de.kitshn.roundToPrecision
 import de.kitshn.ui.component.input.DoubleField
 import kitshn.shared.generated.resources.Res
 import kitshn.shared.generated.resources.action_minus
@@ -52,6 +53,9 @@ class KitshnFormDoubleFieldItem(
 
     val min: () -> Double? = { null },
     val max: () -> Double? = { null },
+
+    val step: Double = 1.0,
+    val precision: Double? = null,
 
     optional: Boolean = false,
 
@@ -90,7 +94,7 @@ class KitshnFormDoubleFieldItem(
             }
         }
 
-        fun step(newValue: Double) {
+        fun commitStep(newValue: Double) {
             val min = min()
             val max = max()
 
@@ -101,6 +105,18 @@ class KitshnFormDoubleFieldItem(
             focusManager.clearFocus(force = true)
             checkValueChange(newValue)
             hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+        }
+
+        fun step(cur: Double?, direction: Int): Double {
+            val snap = precision ?: 1.0
+            if (cur == null) return ceil((min() ?: step) / snap) * snap
+
+            val base = if (direction < 0)
+                floor(cur / snap) * snap
+            else
+                ceil(cur / snap) * snap
+
+            return (base + direction * step).roundToPrecision(snap)
         }
 
         Row(
@@ -126,6 +142,7 @@ class KitshnFormDoubleFieldItem(
 
                 min = min(),
                 max = max(),
+                precision = precision,
 
                 keyboardActions = KeyboardActions(
                     onNext = { focusManager.moveFocus(FocusDirection.Down) }
@@ -155,8 +172,8 @@ class KitshnFormDoubleFieldItem(
                     modifier = Modifier
                         .padding(start = 8.dp),
                     onClick = {
-                        val newValue = value?.let { floor(it) - 1.0 } ?: ceil(min() ?: 1.0)
-                        step(newValue)                    }
+                        commitStep(step(value, -1))
+                    }
                 ) {
                     Icon(Icons.Rounded.Remove, stringResource(Res.string.action_minus))
                 }
@@ -165,8 +182,8 @@ class KitshnFormDoubleFieldItem(
                     modifier = Modifier
                         .padding(start = 4.dp),
                     onClick = {
-                        val newValue = value?.let { ceil(it) + 1.0 } ?: ceil(min() ?: 1.0)
-                        step(newValue)                    }
+                        commitStep(step(value, +1))
+                    }
                 ) {
                     Icon(Icons.Rounded.Add, stringResource(Res.string.action_plus))
                 }

--- a/shared/src/commonMain/kotlin/de/kitshn/model/form/item/field/KitshnFormDoubleFieldItem.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/model/form/item/field/KitshnFormDoubleFieldItem.kt
@@ -36,6 +36,8 @@ import kitshn.shared.generated.resources.form_error_field_empty
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.ceil
+import kotlin.math.floor
 
 class KitshnFormDoubleFieldItem(
     val value: () -> Double?,
@@ -81,11 +83,24 @@ class KitshnFormDoubleFieldItem(
                 generalError = null
                 onValueChange(it)
 
-                error = if(it == null)
+                error = if (it == null)
                     null
                 else
                     check(it)
             }
+        }
+
+        fun step(newValue: Double) {
+            val min = min()
+            val max = max()
+
+            if ((min != null && newValue < min) || (max != null && newValue > max)) {
+                hapticFeedback.performHapticFeedback(HapticFeedbackType.Reject)
+                return
+            }
+            focusManager.clearFocus(force = true)
+            checkValueChange(newValue)
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
         }
 
         Row(
@@ -99,7 +114,7 @@ class KitshnFormDoubleFieldItem(
                 label = {
                     Row {
                         label()
-                        if(!optional) Text("*")
+                        if (!optional) Text("*")
                     }
                 },
 
@@ -121,7 +136,7 @@ class KitshnFormDoubleFieldItem(
                 ),
 
                 isError = error != null || generalError != null,
-                supportingText = if(error != null || generalError != null) {
+                supportingText = if (error != null || generalError != null) {
                     {
                         Text(
                             text = error ?: generalError ?: "",
@@ -140,19 +155,8 @@ class KitshnFormDoubleFieldItem(
                     modifier = Modifier
                         .padding(start = 8.dp),
                     onClick = {
-                        val min = min()
-
-                        val newValue = value?.let { it - 1 } ?: min() ?: 1.0
-                        if(min != null && newValue < min) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Reject)
-                            return@SmallFloatingActionButton
-                        }
-
-                        focusManager.clearFocus(force = true)
-                        checkValueChange(newValue)
-
-                        hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
-                    }
+                        val newValue = value?.let { floor(it) - 1.0 } ?: ceil(min() ?: 1.0)
+                        step(newValue)                    }
                 ) {
                     Icon(Icons.Rounded.Remove, stringResource(Res.string.action_minus))
                 }
@@ -161,19 +165,8 @@ class KitshnFormDoubleFieldItem(
                     modifier = Modifier
                         .padding(start = 4.dp),
                     onClick = {
-                        val max = max()
-
-                        val newValue = value?.let { it + 1 } ?: min() ?: 1.0
-                        if(max != null && newValue > max) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Reject)
-                            return@SmallFloatingActionButton
-                        }
-
-                        focusManager.clearFocus(force = true)
-                        checkValueChange(newValue)
-
-                        hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
-                    }
+                        val newValue = value?.let { ceil(it) + 1.0 } ?: ceil(min() ?: 1.0)
+                        step(newValue)                    }
                 ) {
                     Icon(Icons.Rounded.Add, stringResource(Res.string.action_plus))
                 }
@@ -185,10 +178,10 @@ class KitshnFormDoubleFieldItem(
         val value = value()
         val checkResult = check(value)
 
-        if(!optional && value == null) {
+        if (!optional && value == null) {
             generalError = getString(Res.string.form_error_field_empty)
             return false
-        } else if(checkResult != null) {
+        } else if (checkResult != null) {
             generalError = checkResult
             return false
         } else {

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/component/input/DoubleField.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/component/input/DoubleField.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import co.touchlab.kermit.Logger
 import de.kitshn.formatAmount
+import de.kitshn.roundToPrecision
 
 @Composable
 fun BaseDoubleField(
@@ -31,6 +32,7 @@ fun BaseDoubleField(
     onValueChange: (Double?) -> Unit,
     min: Double? = null,
     max: Double? = null,
+    precision: Double? = null,
     content: @Composable (
         value: String,
         interactionSource: MutableInteractionSource,
@@ -61,7 +63,8 @@ fun BaseDoubleField(
             onValueChange(null)
         } else {
             try {
-                val newValue = uiValue.replace(",", ".").toDouble()
+                var newValue = uiValue.replace(",", ".").toDouble()
+                if(precision != null) newValue = newValue.roundToPrecision(precision)
                 if(min != null && newValue < min) return@content
                 if(max != null && newValue > max) return@content
 
@@ -87,6 +90,7 @@ fun OutlinedDoubleField(
     suffix: @Composable (() -> Unit)? = null,
     min: Double? = null,
     max: Double? = null,
+    precision: Double? = null,
     supportingText: @Composable (() -> Unit)? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
@@ -98,6 +102,7 @@ fun OutlinedDoubleField(
     value = value,
     min = min,
     max = max,
+    precision = precision,
     onValueChange = onValueChange
 ) { v, iso, vc ->
     OutlinedTextField(
@@ -139,6 +144,7 @@ fun DoubleField(
     suffix: @Composable (() -> Unit)? = null,
     min: Double? = null,
     max: Double? = null,
+    precision: Double? = null,
     supportingText: @Composable (() -> Unit)? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
@@ -150,6 +156,7 @@ fun DoubleField(
     value = value,
     min = min,
     max = max,
+    precision = precision,
     onValueChange = onValueChange
 ) { v, iso, v2 ->
     TextField(

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/mealplan/MealPlanCreationAndEditDialog.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/mealplan/MealPlanCreationAndEditDialog.kt
@@ -272,12 +272,12 @@ fun MealPlanCreationAndEditDialog(
                         KitshnFormRecipeSearchFieldItem(
                             client = client,
                             value = { recipeId },
-                            onValueChange = {
-                                recipeId = it
+                            onValueChange = { value ->
+                                recipeId = value
                                 if(recipeId == null) return@KitshnFormRecipeSearchFieldItem
 
                                 client.container.recipeOverview[recipeId]?.servings?.let {
-                                    servings = it.toDouble()
+                                    servings = value?.toDouble()
                                 }
                             },
 
@@ -423,7 +423,7 @@ fun MealPlanCreationAndEditDialog(
                 coroutineScope.launch {
                     if(isEditDialog) {
                         requestMealPlanState.wrapRequest {
-                            editState?.mealPlan?.partialUpdate(
+                            editState.mealPlan?.partialUpdate(
                                 title = title,
                                 recipe = client.container.recipeOverview[recipeId],
                                 servings = servings!!,
@@ -438,7 +438,7 @@ fun MealPlanCreationAndEditDialog(
                         hapticFeedback.handleTandoorRequestState(requestMealPlanState)
 
                         onRefresh()
-                        editState?.dismiss()
+                        editState.dismiss()
                     } else {
                         val mealPlan = requestMealPlanState.wrapRequest {
                             client.mealPlan.create(
@@ -464,7 +464,7 @@ fun MealPlanCreationAndEditDialog(
 
                                 recipeAddToShoppingDialogState.open(
                                     recipe = recipeAddToShoppingDialogRecipe!!,
-                                    servings = servings!!.toDouble()
+                                    servings = servings!!
                                 )
                                 return@launch
                             }

--- a/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/mealplan/MealPlanCreationAndEditDialog.kt
+++ b/shared/src/commonMain/kotlin/de/kitshn/ui/dialog/mealplan/MealPlanCreationAndEditDialog.kt
@@ -308,6 +308,8 @@ fun MealPlanCreationAndEditDialog(
 
                             min = { 0.01 },
 
+                            step = 1.0,
+
                             optional = false,
 
                             check = {


### PR DESCRIPTION
Wanted a bit of distraction from quantum programming exercises so this came in handy for 10 min break.

I removed all warnings of intelij in the dialog and made the buttons step always by integer amounts.
Then i though a step and precision would be a good addition so i added that aswell.
Step is the interval the buttons step by
and precision is the well the precision of the whole double field